### PR TITLE
Add pdf2image package to installation command

### DIFF
--- a/10-Understanding-BDA/13_custom_outputs_and_blueprints.ipynb
+++ b/10-Understanding-BDA/13_custom_outputs_and_blueprints.ipynb
@@ -98,7 +98,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --no-warn-conflicts \"boto3>=1.37.6\" itables==2.2.4 PyPDF2==3.0.1 --upgrade -qq"
+    "%pip install --no-warn-conflicts \"boto3>=1.37.6\" itables==2.2.4 PyPDF2==3.0.1 pdf2image==1.17.0 --upgrade -qq"
    ]
   },
   {


### PR DESCRIPTION


*Description of changes:*
 Got some issues when we start a virgin python venv inside the Jupyter, we can miss some dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
